### PR TITLE
Use mod_auth_mellon with Apache httpd to connect SAMLv2

### DIFF
--- a/stable/alfresco-content-services-community/README.md
+++ b/stable/alfresco-content-services-community/README.md
@@ -121,7 +121,7 @@ unset _HOST
 
 Both files `mellon.key` and `mellon.crt` will be injected in `values.yaml`.
 
-Then get the SDP metadata file in XML format.
+Then get the IDP metadata file in XML format.
 
 In `values.yaml` (or any other anwser file you use with `-f` option from helm command line), add or modify the `mellon` section:
 
@@ -170,14 +170,14 @@ mellon:
   - name: email
     set_header: X-Alfresco-Remote-Email
 
-  # The SP name to register in SAML SDP
+  # The SP name to register in SAML IDP
   entity_id: alfresco
   cert: |
     # paste here the SP certificate
   key: |
     # paste here the SP key
   idp_metadata: |
-    # paste here the XML content of SDP Metadata
+    # paste here the XML content of IDP Metadata
 ```
 
 You also need to change the global properties configmap. Somewhere in , add:

--- a/stable/alfresco-content-services-community/README.md
+++ b/stable/alfresco-content-services-community/README.md
@@ -82,7 +82,7 @@ Parameter | Description | Default
 `alfresco-search.ingress.basicAuth` | If `alfresco-search.ingress.enabled` is `true`, user need to provide a `base64` encoded `htpasswd` format user name & password (ex: `echo -n "$(htpasswd -nbm solradmin somepassword)"` where `solradmin` is username and `somepassword` is the password) | None
 `alfresco-search.ingress.whitelist_ips` | If `alfresco-search.ingress.enabled` is `true`, user can restrict `/solr` to a list of IP addresses of CIDR notation | `0.0.0.0/0`
 
-# Activate Apahce Mellon
+# Activate Apache Mellon
 
 You can activate Apache Mellon to authenticate users from SAMLv2 server.
 

--- a/stable/alfresco-content-services-community/templates/config-apache-mellon-meta.yaml
+++ b/stable/alfresco-content-services-community/templates/config-apache-mellon-meta.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.mellon.enabled -}}
+apiVersion: v1
+data:
+  mellon.crt: |
+{{ .Values.mellon.cert | indent 4 }}
+
+  mellon.key: |
+{{ .Values.mellon.key | indent 4 }}
+
+  metadata.xml: |
+{{ .Values.mellon.idp_metadata | indent 4 }}
+
+
+  mellon_metadata.xml: |
+    <EntityDescriptor entityID="{{ .Values.mellon.entity_id }}" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <KeyDescriptor use="signing">
+          <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:X509Data>
+              <ds:X509Certificate>{{- .Values.mellon.cert | replace "-----BEGIN CERTIFICATE-----" "" | replace "-----END CERTIFICATE-----" "" | indent 4 | trim }}</ds:X509Certificate>
+            </ds:X509Data>
+          </ds:KeyInfo>
+        </KeyDescriptor>
+        <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="{{ .Values.externalProtocol }}://{{ .Values.externalHost }}/mellon/logout"/>
+        <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="{{ .Values.externalProtocol }}://{{ .Values.externalHost }}/mellon/postResponse" index="0"/>
+      </SPSSODescriptor>
+    </EntityDescriptor>
+
+kind: ConfigMap
+metadata:
+  name: {{ template "content-services.shortname" . }}-apache-mellon-meta
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: apache-mellon
+{{- end -}}

--- a/stable/alfresco-content-services-community/templates/config-apache-mellon.yaml
+++ b/stable/alfresco-content-services-community/templates/config-apache-mellon.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.mellon.enabled -}}
+apiVersion: v1
+data:
+  welcome.conf: |
+    #
+    # This configuration file enables the default "Welcome" page if there
+    # is no default index page present for the root URL.  To disable the
+    # Welcome page, comment out all the lines below.
+    #
+    # NOTE: if this file is removed, it will be restored on upgrades.
+
+    {{ .Values.mellon.server_snippets | indent 4 | trim }}
+
+    <LocationMatch "^/+$">
+        Options -Indexes
+        ErrorDocument 403 /.noindex.html
+    </LocationMatch>
+
+    <Directory /usr/share/httpd/noindex>
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+    Alias /.noindex.html /usr/share/httpd/noindex/index.html
+    Alias /noindex/css/bootstrap.min.css /usr/share/httpd/noindex/css/bootstrap.min.css
+    Alias /noindex/css/open-sans.css /usr/share/httpd/noindex/css/open-sans.css
+    Alias /images/apache_pb.gif /usr/share/httpd/noindex/images/apache_pb.gif
+    Alias /images/poweredby.png /usr/share/httpd/noindex/images/poweredby.png
+
+  auth_mellon.conf: |
+    MellonCacheSize 100
+    MellonLockFile "/run/mod_auth_mellon/lock"
+
+    <Location / >
+        MellonEnable "off"
+        MellonEndpointPath /mellon/
+        MellonSPMetadataFile /etc/httpd/saml2/mellon_metadata.xml
+        MellonSPPrivateKeyFile /etc/httpd/saml2/mellon.key
+        MellonSPCertFile /etc/httpd/saml2/mellon.crt
+        MellonIdPMetadataFile /etc/httpd/saml2/metadata.xml
+
+        {{ with .Values.mellon.saml_attributes }}
+        {{ range .}}
+        RequestHeader unset {{ .name }}
+        RequestHeader set {{ .set_header }} "%{MELLON_{{ .name }}}e" env=MELLON_{{ .name }}
+        {{ end -}}
+        {{ end }}
+
+        RequestHeader set secure_key "secure"
+    </Location>
+
+    {{ $contentservice :=  include "content-services.shortname" . }}
+    {{ $defaultBakend := printf "http://%s" $contentservice}}
+    {{ with .Values.mellon.allowed_routes }}
+    {{ range .}}
+    <Location {{ .path }} >
+        ProxyPass  {{ printf "%s%s/%s" (.backend | default $defaultBakend | trimSuffix "/") .suffix (.path | trimPrefix "/" ) | quote }}
+    </Location>
+    {{ end -}}
+    {{ end }}
+
+    {{ with .Values.mellon.protected_routes }}
+    {{ range .}}
+    <Location {{ .path }} >
+        AuthType Mellon
+        MellonEnable auth
+        Require valid-user
+        ProxyPass  {{ printf "%s%s/%s" (.backend | default $defaultBakend | trimSuffix "/") .suffix (.path | trimPrefix "/" ) | quote }}
+    </Location>
+    {{ end -}}
+    {{ end }}
+kind: ConfigMap
+metadata:
+  name: {{ template "content-services.shortname" . }}-apache-mellon-config
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: apache-mellon
+{{- end -}}

--- a/stable/alfresco-content-services-community/templates/config-share-config.yaml
+++ b/stable/alfresco-content-services-community/templates/config-share-config.yaml
@@ -1,0 +1,765 @@
+{{- if .Values.mellon.enabled -}}
+apiVersion: v1
+data:
+    share-config-custom.xml: |
+        <alfresco-config>
+
+           <!-- Global config section -->
+           <config replace="true">
+              <flags>
+                 <!--
+                    Developer debugging setting to turn on DEBUG mode for client scripts in the browser
+                 -->
+                 <client-debug>false</client-debug>
+
+                 <!--
+                    LOGGING can always be toggled at runtime when in DEBUG mode (Ctrl, Ctrl, Shift, Shift).
+                    This flag automatically activates logging on page load.
+                 -->
+                 <client-debug-autologging>false</client-debug-autologging>
+              </flags>
+           </config>
+
+           <config evaluator="string-compare" condition="WebFramework">
+              <web-framework>
+                 <!-- SpringSurf Autowire Runtime Settings -->
+                 <!--
+                      Developers can set mode to 'development' to disable; SpringSurf caches,
+                      FreeMarker template caching and Rhino JavaScript compilation.
+                 -->
+                 <autowire>
+                    <!-- Pick the mode: "production" or "development" -->
+                    <mode>production</mode>
+                 </autowire>
+
+                 <!-- Allows extension modules with <auto-deploy> set to true to be automatically deployed -->
+                 <module-deployment>
+                    <mode>manual</mode>
+                    <enable-auto-deploy-modules>true</enable-auto-deploy-modules>
+                 </module-deployment>
+              </web-framework>
+           </config>
+
+
+           <!--
+              CSRF filter config to mitigate CSRF/Seasurfing/XSRF attacks
+
+              To disable the CSRF filter override the <filter> to not contain any values, see share-config-custom.xml for
+              an example.
+
+              If you have a custom resource(s) that a client POST to that can't accept a token, for whatever reason, then make
+              sure to copy the entire CSRFPolicy config and place it in your share-config-custom.xml file
+              with the replace="true" attribute and make sure to add a new <rule> in the top of the <filter> element,
+              which has a <request> element matching your requests, and uses only the "assertReferer" & "assertOrigin" actions.
+
+              I.e.
+              <rule>
+                 <request>
+                    <method>POST</method>
+                    <path>/proxy/alfresco/custom/repoWebscript/withoutParams|/service/custom/shareResource/thatMayHaveParams(\?.+)?</path>
+                 </request>
+                 <action name="assertReferer">
+                    <param name="referer">{referer}</param>
+                 </action>
+                 <action name="assertOrigin">
+                    <param name="origin">{origin}</param>
+                 </action>
+              </rule>
+           -->
+           <config evaluator="string-compare" condition="CSRFPolicy" replace="false">
+
+              <!--
+                 Properties that may be used inside the rest of the CSRFPolicy config to avoid repetition but
+                 also making it possible to provide different values in different environments.
+                 I.e. Different "Referer" & "Origin" properties for test & production etc.
+                 Reference a property using "{propertyName}".
+              -->
+              <properties>
+
+                 <!-- There is normally no need to override this property -->
+                 <token>Alfresco-CSRFToken</token>
+
+                 <!--
+                    Override and set this property with a regexp that if you have placed Share behind a proxy that
+                    does not rewrite the Referer header.
+                 -->
+                 <referer></referer>
+
+                 <!--
+                    Override and set this property with a regexp that if you have placed Share behind a proxy that
+                    does not rewrite the Origin header.
+                 -->
+                 <origin></origin>
+              </properties>
+
+              <!--
+                Will be used and exposed to the client side code in Alfresco.contants.CSRF_POLICY.
+                Use the Alfresco.util.CSRFPolicy.getHeader() or Alfresco.util.CSRFPolicy.getParameter() with Alfresco.util.CSRFPolicy.getToken()
+                to set the token in custom 3rd party code.
+              -->
+              <client>
+                 <cookie>{token}</cookie>
+                 <header>{token}</header>
+                 <parameter>{token}</parameter>
+              </client>
+
+              <!-- The first rule with a matching request will get its action invoked, the remaining rules will be ignored. -->
+              <filter>
+
+                 <!--
+                    Certain webscripts shall not be allowed to be accessed directly form the browser.
+                    Make sure to throw an error if they are used.
+                 -->
+                 <rule>
+                    <request>
+                       <path>/proxy/alfresco/remoteadm/.*</path>
+                    </request>
+                    <action name="throwError">
+                       <param name="message">It is not allowed to access this url from your browser</param>
+                    </action>
+                 </rule>
+
+                 <!--
+                    Certain Repo webscripts should be allowed to pass without a token since they have no Share knowledge.
+                    TODO: Refactor the publishing code so that form that is posted to this URL is a Share webscript with the right tokens.
+                 -->
+                 <rule>
+                    <request>
+                       <method>POST</method>
+                       <path>/proxy/alfresco/api/publishing/channels/.+</path>
+                    </request>
+                    <action name="assertReferer">
+                       <param name="referer">{referer}</param>
+                    </action>
+                    <action name="assertOrigin">
+                       <param name="origin">{origin}</param>
+                    </action>
+                 </rule>
+
+                 <!--
+                    Certain Surf POST requests from the WebScript console must be allowed to pass without a token since
+                    the Surf WebScript console code can't be dependent on a Share specific filter.
+                 -->
+                 <rule>
+                    <request>
+                       <method>POST</method>
+                       <path>
+                          /page/caches/dependency/clear|/page/index|/page/surfBugStatus|/page/modules/deploy|/page/modules/module|/page/api/javascript/debugger|/page/console
+                       </path>
+                    </request>
+                    <action name="assertReferer">
+                       <param name="referer">{referer}</param>
+                    </action>
+                    <action name="assertOrigin">
+                       <param name="origin">{origin}</param>
+                    </action>
+                 </rule>
+
+                 <!-- Certain Share POST requests does NOT require a token -->
+                 <rule>
+                    <request>
+                       <method>POST</method>
+                       <path>
+                          /page/dologin(\?.+)?|/page/site/[^/]+/start-workflow|/page/start-workflow|/page/context/[^/]+/start-workflow
+                       </path>
+                    </request>
+                    <action name="assertReferer">
+                       <param name="referer">{referer}</param>
+                    </action>
+                    <action name="assertOrigin">
+                       <param name="origin">{origin}</param>
+                    </action>
+                 </rule>
+
+                 <!-- Assert logout is done from a valid domain, if so clear the token when logging out -->
+                 <rule>
+                    <request>
+                       <method>POST</method>
+                       <path>/page/dologout(\?.+)?</path>
+                    </request>
+                    <action name="assertReferer">
+                       <param name="referer">{referer}</param>
+                    </action>
+                    <action name="assertOrigin">
+                       <param name="origin">{origin}</param>
+                    </action>
+                    <action name="clearToken">
+                       <param name="session">{token}</param>
+                       <param name="cookie">{token}</param>
+                    </action>
+                 </rule>
+
+                 <!-- Make sure the first token is generated -->
+                 <rule>
+                    <request>
+                       <session>
+                          <attribute name="_alf_USER_ID">.+</attribute>
+                          <attribute name="{token}" />
+                          <!-- empty attribute element indicates null, meaning the token has not yet been set -->
+                       </session>
+                    </request>
+                    <action name="generateToken">
+                       <param name="session">{token}</param>
+                       <param name="cookie">{token}</param>
+                    </action>
+                 </rule>
+
+                 <!-- Refresh token on new "page" visit when a user is logged in -->
+                 <rule>
+                    <request>
+                       <method>GET</method>
+                       <path>/page/.*</path>
+                       <session>
+                          <attribute name="_alf_USER_ID">.+</attribute>
+                          <attribute name="{token}">.+</attribute>
+                       </session>
+                    </request>
+                    <action name="generateToken">
+                       <param name="session">{token}</param>
+                       <param name="cookie">{token}</param>
+                    </action>
+                 </rule>
+
+                 <!--
+                    Verify multipart requests from logged in users contain the token as a parameter
+                    and also correct referer & origin header if available
+                 -->
+                 <rule>
+                    <request>
+                       <method>POST</method>
+                       <header name="Content-Type">multipart/.+</header>
+                       <session>
+                          <attribute name="_alf_USER_ID">.+</attribute>
+                       </session>
+                    </request>
+                    <action name="assertToken">
+                       <param name="session">{token}</param>
+                       <param name="parameter">{token}</param>
+                    </action>
+                    <action name="assertReferer">
+                       <param name="referer">{referer}</param>
+                    </action>
+                    <action name="assertOrigin">
+                       <param name="origin">{origin}</param>
+                    </action>
+                 </rule>
+
+                 <!--
+                    Verify that all remaining state changing requests from logged in users' requests contains a token in the
+                    header and correct referer & origin headers if available. We "catch" all content types since just setting it to
+                    "application/json.*" since a webscript that doesn't require a json request body otherwise would be
+                    successfully executed using i.e."text/plain".
+                 -->
+                 <rule>
+                    <request>
+                       <method>POST|PUT|DELETE</method>
+                       <session>
+                          <attribute name="_alf_USER_ID">.+</attribute>
+                       </session>
+                    </request>
+                    <action name="assertToken">
+                       <param name="session">{token}</param>
+                       <param name="header">{token}</param>
+                    </action>
+                    <action name="assertReferer">
+                       <param name="referer">{referer}</param>
+                    </action>
+                    <action name="assertOrigin">
+                       <param name="origin">{origin}</param>
+                    </action>
+                 </rule>
+              </filter>
+
+           </config>
+
+
+           <!--
+              Remove the default wildcard setting and use instead a strict whitelist of the only domains that shall be allowed
+              to be used inside iframes (i.e. in the WebView dashlet on the dashboards)
+           -->
+           <!--
+           <config evaluator="string-compare" condition="IFramePolicy" replace="true">
+              <cross-domain>
+                 <url>http://www.trusted-domain-1.com/</url>
+                 <url>http://www.trusted-domain-2.com/</url>
+              </cross-domain>
+           </config>
+           -->
+
+           <!-- Turn off header that stops Share from being displayed in iframes on pages from other domains -->
+           <!--
+           <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+              <headers>
+                 <header>
+                    <name>X-Frame-Options</name>
+                    <enabled>false</enabled>
+                 </header>
+              </headers>
+           </config>
+           -->
+
+           <!-- Prevent browser communication over HTTP (for HTTPS servers) -->
+           <!--
+           <config evaluator="string-compare" condition="SecurityHeadersPolicy">
+              <headers>
+                 <header>
+                    <name>Strict-Transport-Security</name>
+                    <value>max-age=31536000</value>
+                 </header>
+              </headers>
+           </config>
+           -->
+
+           <config evaluator="string-compare" condition="Replication">
+              <share-urls>
+                 <!--
+                    To locate your current repositoryId go to Admin Console > General > Repository Information:
+                      http://localhost:8080/alfresco/s/enterprise/admin/admin-repositoryinfo
+
+                    Example config entry:
+                      <share-url repositoryId="622f9533-2a1e-48fe-af4e-ee9e41667ea4">http://new-york-office:8080/share/</share-url>
+                 -->
+              </share-urls>
+           </config>
+
+           <!-- Document Library config section -->
+           <config evaluator="string-compare" condition="DocumentLibrary" replace="true">
+
+              <tree>
+                 <!--
+                    Whether the folder Tree component should enumerate child folders or not.
+                    This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+                 -->
+                 <evaluate-child-folders>false</evaluate-child-folders>
+
+                 <!--
+                    Optionally limit the number of folders shown in treeview throughout Share.
+                 -->
+                 <maximum-folder-count>1000</maximum-folder-count>
+
+                 <!--
+                    Default timeout in milliseconds for folder Tree component to recieve response from Repository
+                 -->
+                 <timeout>7000</timeout>
+              </tree>
+
+              <!--
+                 Used by "Manage Rules" -> "Add aspect" action.
+
+                 If an aspect has been specified without a title element in the content model,
+                 or you need to support multiple languages,
+                 then an i18n file is needed on the Repo AMP/JAR extension side for the aspect to
+                 be visible when creating rules:
+
+                  custom_customModel.aspect.custom_myaspect.title=My Aspect
+
+                 Used by the "Manage Aspects" action.
+
+                 For the aspect to have a localised label add relevant i18n string(s) in a Share AMP/JAR extension:
+
+                  aspect.custom_myaspect=My Aspect
+              -->
+              <aspects>
+                 <!-- Aspects that a user can see -->
+                 <visible>
+                    <aspect name="cm:generalclassifiable" />
+                    <aspect name="cm:complianceable" />
+                    <aspect name="cm:dublincore" />
+                    <aspect name="cm:effectivity" />
+                    <aspect name="cm:summarizable" />
+                    <aspect name="cm:versionable" />
+                    <aspect name="cm:templatable" />
+                    <aspect name="cm:emailed" />
+                    <aspect name="emailserver:aliasable" />
+                    <aspect name="cm:taggable" />
+                    <aspect name="app:inlineeditable" />
+                    <aspect name="cm:geographic" />
+                    <aspect name="exif:exif" />
+                    <aspect name="audio:audio" />
+                    <aspect name="cm:indexControl" />
+                    <aspect name="dp:restrictable" />
+                    <aspect name="smf:customConfigSmartFolder" />
+                    <aspect name="smf:systemConfigSmartFolder" />
+                 </visible>
+
+                 <!-- Aspects that a user can add. Same as "visible" if left empty -->
+                 <addable>
+                 </addable>
+
+                 <!-- Aspects that a user can remove. Same as "visible" if left empty -->
+                 <removeable>
+                 </removeable>
+              </aspects>
+
+              <!--
+                 Used by "Manage Rules" -> "Specialise type" action.
+
+                 If a type has been specified without a title element in the content model,
+                 or you need to support multiple languages,
+                 then an i18n file is needed on the Repo AMP/JAR extension side for the type to
+                 be visible when creating rules:
+
+                    custom_customModel.type.custom_mytype.title=My SubType
+
+                 Used by the "Change Type" action.
+
+                 For the type to have a localised label add relevant i18n string(s) in a Share AMP/JAR extension:
+
+                    type.custom_mytype=My SubType
+
+                 Define valid subtypes using the following example:
+
+                    <type name="cm:content">
+                     <subtype name="custom:mytype" />
+                    </type>
+              -->
+              <types>
+                 <type name="cm:content">
+                    <subtype name="smf:smartFolderTemplate" />
+                 </type>
+
+                  <type name="cm:folder">
+                 </type>
+
+                 <type name="trx:transferTarget">
+                    <subtype name="trx:fileTransferTarget" />
+                 </type>
+              </types>
+
+              <!--
+                 If set, will present a WebDAV link for the current item on the Document and Folder details pages.
+                 Also used to generate the "View in Alfresco Explorer" action for folders.
+              -->
+              <repository-url>http://REPO_HOST:REPO_PORT/alfresco</repository-url>
+
+              <!--
+                 Google Docs™ integration
+              -->
+              <google-docs>
+                 <!--
+                    Enable/disable the Google Docs UI integration (Extra types on Create Content menu, Google Docs actions).
+                 -->
+                 <enabled>false</enabled>
+
+                 <!--
+                    The mimetypes of documents Google Docs allows you to create via the Share interface.
+                    The I18N label is created from the "type" attribute, e.g. google-docs.doc=Google Docs&trade; Document
+                 -->
+                 <creatable-types>
+                    <creatable type="doc">application/vnd.openxmlformats-officedocument.wordprocessingml.document</creatable>
+                    <creatable type="xls">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</creatable>
+                    <creatable type="ppt">application/vnd.ms-powerpoint</creatable>
+                 </creatable-types>
+              </google-docs>
+
+              <!--
+                 File upload configuration
+              -->
+              <file-upload>
+                 <!--
+                    Adobe Flash™
+                    In certain environments, an HTTP request originating from Flash cannot be authenticated using an existing session.
+                    See: http://bugs.adobe.com/jira/browse/FP-4830
+                    For these cases, it is useful to disable the Flash-based uploader for Share Document Libraries.
+                 -->
+                 <adobe-flash-enabled>true</adobe-flash-enabled>
+              </file-upload>
+           </config>
+
+
+           <!-- Custom DocLibActions config section -->
+           <config evaluator="string-compare" condition="DocLibActions">
+              <actionGroups>
+                 <actionGroup id="document-browse">
+
+                    <!-- Simple Repo Actions -->
+                    <!--
+                    <action index="340" id="document-extract-metadata" />
+                    <action index="350" id="document-increment-counter" />
+                    -->
+
+                    <!-- Dialog Repo Actions -->
+                    <!--
+                    <action index="360" id="document-transform" />
+                    <action index="370" id="document-transform-image" />
+                    <action index="380" id="document-execute-script" />
+                    -->
+
+                 </actionGroup>
+              </actionGroups>
+           </config>
+
+           <!-- Global folder picker config section -->
+           <config evaluator="string-compare" condition="GlobalFolder">
+              <siteTree>
+                 <container type="cm:folder">
+                    <!-- Use a specific label for this container type in the tree -->
+                    <rootLabel>location.path.documents</rootLabel>
+                    <!-- Use a specific uri to retreive the child nodes for this container type in the tree -->
+                    <uri>slingshot/doclib/treenode/site/{site}/{container}{path}?children={evaluateChildFoldersSite}&amp;max={maximumFolderCountSite}</uri>
+                 </container>
+              </siteTree>
+           </config>
+
+           <!-- Repository Library config section -->
+           <config evaluator="string-compare" condition="RepositoryLibrary" replace="true">
+              <!--
+                 Root nodeRef or xpath expression for top-level folder.
+                 e.g. alfresco://user/home, /app:company_home/st:sites/cm:site1
+                 If using an xpath expression, ensure it is properly ISO9075 encoded here.
+              -->
+              <root-node>alfresco://company/home</root-node>
+
+              <tree>
+                 <!--
+                    Whether the folder Tree component should enumerate child folders or not.
+                    This is a relatively expensive operation, so should be set to "false" for Repositories with broad folder structures.
+                 -->
+                 <evaluate-child-folders>false</evaluate-child-folders>
+
+                 <!--
+                    Optionally limit the number of folders shown in treeview throughout Share.
+                 -->
+                 <maximum-folder-count>500</maximum-folder-count>
+              </tree>
+
+              <!--
+                 Whether the link to the Repository Library appears in the header component or not.
+              -->
+              <visible>true</visible>
+           </config>
+
+           <!-- Kerberos settings -->
+           <!-- To enable kerberos rename this condition to "Kerberos" -->
+           <config evaluator="string-compare" condition="KerberosDisabled" replace="true">
+              <kerberos>
+                 <!--
+                    Password for HTTP service account.
+                    The account name *must* be built from the HTTP server name, in the format :
+                       HTTP/<server_name>@<realm>
+                    (NB this is because the web browser requests an ST for the
+                    HTTP/<server_name> principal in the current realm, so if we're to decode
+                    that ST, it has to match.)
+                 -->
+                 <password>secret</password>
+                 <!--
+                    Kerberos realm and KDC address.
+                 -->
+                 <realm>ALFRESCO.ORG</realm>
+                 <!--
+                    Service Principal Name to use on the repository tier.
+                    This must be like: HTTP/host.name@REALM
+                 -->
+                 <endpoint-spn>HTTP/repository.server.com@ALFRESCO.ORG</endpoint-spn>
+                 <!--
+                    JAAS login configuration entry name.
+                 -->
+                 <config-entry>ShareHTTP</config-entry>
+                <!--
+                   A Boolean which when true strips the @domain sufix from Kerberos authenticated usernames.
+                   Use together with stripUsernameSuffix property in alfresco-global.properties file.
+                -->
+                <stripUserNameSuffix>true</stripUserNameSuffix>
+              </kerberos>
+           </config>
+
+           <!-- Uncomment and modify the URL to Activiti Admin Console if required. -->
+           <!--
+           <config evaluator="string-compare" condition="ActivitiAdmin" replace="true">
+              <activiti-admin-url>http://localhost:8080/alfresco/activiti-admin</activiti-admin-url>
+           </config>
+           -->
+
+           <config evaluator="string-compare" condition="Remote">
+              <remote>
+                  <connector>
+                    <id>alfrescoHeader</id>
+                    <name>Alfresco Connector</name>
+                    <description>Connects to an Alfresco instance using header and cookie-based authentication</description>
+                    <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+                    <userHeader>{{ .Values.mellon.connector_header }}</userHeader>
+                 </connector>
+                 <endpoint>
+                    <id>alfresco-noauth</id>
+                    <name>Alfresco - unauthenticated access</name>
+                    <description>Access to Alfresco Repository WebScripts that do not require authentication</description>
+                    <connector-id>alfrescoHeader</connector-id>
+                    <endpoint-url>http://REPO_HOST:REPO_PORT/alfresco/s</endpoint-url>
+                    <identity>none</identity>
+                    <external-auth>true</external-auth>
+                 </endpoint>
+
+                 <endpoint>
+                    <id>alfresco</id>
+                    <name>Alfresco - user access</name>
+                    <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+                    <connector-id>alfrescoHeader</connector-id>
+                    <endpoint-url>http://REPO_HOST:REPO_PORT/alfresco/s</endpoint-url>
+                    <identity>user</identity>
+                    <external-auth>true</external-auth>
+                 </endpoint>
+
+                 <endpoint>
+                    <id>alfresco-feed</id>
+                    <name>Alfresco Feed</name>
+                    <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
+                    <connector-id>alfrescoHeader</connector-id>
+                    <endpoint-url>http://REPO_HOST:REPO_PORT/alfresco/s</endpoint-url>
+                    <basic-auth>true</basic-auth>
+                    <identity>user</identity>
+                 </endpoint>
+
+                 <endpoint>
+                    <id>alfresco-api</id>
+                    <parent-id>alfresco</parent-id>
+                    <name>Alfresco Public API - user access</name>
+                    <description>Access to Alfresco Repository Public API that require user authentication.
+                                 This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+                    <connector-id>alfrescoHeader</connector-id>
+                    <endpoint-url>http://REPO_HOST:REPO_PORT/alfresco/api</endpoint-url>
+                    <identity>user</identity>
+                    <external-auth>true</external-auth>
+                 </endpoint>
+              </remote>
+           </config>
+
+           <config evaluator="string-compare" condition="Users" replace="true">
+              <users>
+                 <!-- minimum length for username and password -->
+                 <username-min-length>2</username-min-length>
+                 <password-min-length>3</password-min-length>
+                 <show-authorization-status>true</show-authorization-status>
+              </users>
+              <!-- This enables/disables the Add External Users Panel on the Add Users page. -->
+              <enable-external-users-panel>false</enable-external-users-panel>
+           </config>
+
+           <!--
+                Overriding endpoints to reference an Alfresco server with external SSO enabled
+                NOTE: If utilising a load balancer between web-tier and repository cluster, the "sticky
+                      sessions" feature of your load balancer must be used.
+                NOTE: If alfresco server location is not localhost:8080 then also combine changes from the
+                      "example port config" section below.
+                *Optional* ssl-config contains:
+                      keystore for managing client key and certificate.
+                      truststore for managing trusted CAs.
+                Used to authenticate share to an external SSO system such as CAS or
+                to make share talk to SSL layers that require client certificates.
+                Remove the ssl-config section if not required i.e. for NTLM.
+
+                NOTE: For Kerberos SSO rename the "KerberosDisabled" condition above to "Kerberos"
+
+                NOTE: For external SSO, switch the endpoint connector to "alfrescoHeader" and set
+                      the userHeader value to the name of the HTTP header that the external SSO
+                      uses to provide the authenticated user name.
+                NOTE: For external SSO, Share now supports the "userIdPattern" mechanism as is available
+                      on the repository config for External Authentication sub-system. Add the following
+                      element to your "alfrescoHeader" connector config:
+                      <userIdPattern>^ignore-(\w+)-ignore</userIdPattern>
+                      This is an example, ensure the Id pattern matches your repository config.
+                NOTE: For external SSO, Share now supports stateless (no Http Session or sticky session)
+                      connection to the repository when using the alfrescoHeader remote user connector.
+                      e.g. You can change endpoint config to use the faster /service URL instead of the
+                      /wcs URL if you are using External Authentication and then remove sticky session config
+                      from your proxy between Share and Alfresco. Note that this is also faster because Share
+                      will no longer call the /touch REST API before every remote call to the repository.
+           -->
+
+           <!-- Security warning -->
+           <!-- For production environment set verify-hostname to true.-->
+           <!--
+           <config evaluator="string-compare" condition="Remote">
+              <remote>
+                 <ssl-config>
+                    <keystore-path>alfresco/web-extension/alfresco-system.p12</keystore-path>
+                    <keystore-type>pkcs12</keystore-type>
+                    <keystore-password>alfresco-system</keystore-password>
+
+                    <truststore-path>alfresco/web-extension/ssl-truststore</truststore-path>
+                    <truststore-type>JCEKS</truststore-type>
+                    <truststore-password>password</truststore-password>
+
+                    <verify-hostname>true</verify-hostname>
+                 </ssl-config>
+
+                 <connector>
+                    <id>alfrescoCookie</id>
+                    <name>Alfresco Connector</name>
+                    <description>Connects to an Alfresco instance using cookie-based authentication</description>
+                    <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+                 </connector>
+
+                 <connector>
+                    <id>alfrescoHeader</id>
+                    <name>Alfresco Connector</name>
+                    <description>Connects to an Alfresco instance using header and cookie-based authentication</description>
+                    <class>org.alfresco.web.site.servlet.SlingshotAlfrescoConnector</class>
+                    <userHeader>SsoUserHeader</userHeader>
+                 </connector>
+
+                 <endpoint>
+                    <id>alfresco</id>
+                    <name>Alfresco - user access</name>
+                    <description>Access to Alfresco Repository WebScripts that require user authentication</description>
+                    <connector-id>alfrescoCookie</connector-id>
+                    <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+                    <identity>user</identity>
+                    <external-auth>true</external-auth>
+                 </endpoint>
+
+                 <endpoint>
+                    <id>alfresco-feed</id>
+                    <parent-id>alfresco</parent-id>
+                    <name>Alfresco Feed</name>
+                    <description>Alfresco Feed - supports basic HTTP authentication via the EndPointProxyServlet</description>
+                    <connector-id>alfrescoHeader</connector-id>
+                    <endpoint-url>http://localhost:8080/alfresco/wcs</endpoint-url>
+                    <identity>user</identity>
+                    <external-auth>true</external-auth>
+                 </endpoint>
+
+                 <endpoint>
+                    <id>alfresco-api</id>
+                    <parent-id>alfresco</parent-id>
+                    <name>Alfresco Public API - user access</name>
+                    <description>Access to Alfresco Repository Public API that require user authentication.
+                                 This makes use of the authentication that is provided by parent 'alfresco' endpoint.</description>
+                    <connector-id>alfrescoHeader</connector-id>
+                    <endpoint-url>http://localhost:8080/alfresco/api</endpoint-url>
+                    <identity>user</identity>
+                    <external-auth>true</external-auth>
+                 </endpoint>
+              </remote>
+           </config>
+           -->
+
+           <!-- Cookie settings -->
+           <!-- To disable alfUsername2 cookie set enableCookie value to "false" -->
+           <!--
+           <plug-ins>
+              <element-readers>
+                 <element-reader element-name="cookie" class="org.alfresco.web.config.cookie.CookieElementReader"/>
+              </element-readers>
+           </plug-ins>
+
+           <config evaluator="string-compare" condition="Cookie" replace="true">
+              <cookie>
+                 <enableCookie>false</enableCookie>
+                 <cookies-to-remove>
+                    <cookie-to-remove>alfUsername3</cookie-to-remove>
+                    <cookie-to-remove>alfLogin</cookie-to-remove>
+                 </cookies-to-remove>
+              </cookie>
+           </config>
+           -->
+        </alfresco-config>
+
+kind: ConfigMap
+metadata:
+  name: {{ template "content-services.shortname" . }}-share-config
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    component: share
+{{- end -}}

--- a/stable/alfresco-content-services-community/templates/deployment-apache-mellon.yaml
+++ b/stable/alfresco-content-services-community/templates/deployment-apache-mellon.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.mellon.enabled -}}
+apiVersion: {{ template "deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: {{ template "content-services.shortname" . }}-apache-mellon
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: appache-mellon
+  name: {{ template "content-services.shortname" . }}-apache-mellon
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "content-services.shortname" . }}-apache-mellon
+      release: {{ .Release.Name }}
+      component: apache-mellon
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: {{ template "content-services.shortname" . }}-apache-mellon
+        release: {{ .Release.Name }}
+        component: apache-mellon
+    spec:
+      containers:
+      - image: {{ .Values.mellon.image }}
+        name: apache-mellon
+        resources: {}
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /etc/httpd/conf.d
+          name: apache-mellon-config
+        - mountPath: /etc/httpd/saml2
+          name: apache-mellon-meta
+
+      volumes:
+        - name: apache-mellon-config
+          configMap:
+            name: {{ template "content-services.shortname" . }}-apache-mellon-config
+        - name: apache-mellon-meta
+          configMap:
+            name: {{ template "content-services.shortname" . }}-apache-mellon-meta
+status: {}
+{{- end -}}

--- a/stable/alfresco-content-services-community/templates/deployment-share.yaml
+++ b/stable/alfresco-content-services-community/templates/deployment-share.yaml
@@ -36,6 +36,16 @@ spec:
             - containerPort: {{ .Values.share.image.internalPort }}
           resources:
 {{ toYaml .Values.share.resources | indent 12 }}
+          {{ if .Values.mellon.enabled }}
+          volumeMounts:
+          - mountPath: /opt/share-config-custom.xml
+            name: share-custom
+            subPath: share-config-custom.xml
+          command:
+            - /bin/bash
+            - -c
+            - 'cat /opt/share-config-custom.xml > /usr/local/tomcat/shared/classes/alfresco/web-extension/share-config-custom.xml && /usr/local/tomcat/shared/classes/alfresco/substituter.sh "catalina.sh run"'
+          {{ end }}
           envFrom:
           - configMapRef:
               name: {{ template "content-services.shortname" . }}-share-configmap
@@ -54,3 +64,9 @@ spec:
             periodSeconds: {{ .Values.share.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.share.livenessProbe.timeoutSeconds }}
+      {{ if .Values.mellon.enabled }}
+      volumes:
+      - name: share-custom
+        configMap:
+          name: {{ template "content-services.shortname" . }}-share-config
+      {{ end }}

--- a/stable/alfresco-content-services-community/templates/ingress-mellon-protected.yaml
+++ b/stable/alfresco-content-services-community/templates/ingress-mellon-protected.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.mellon.enabled -}}
+{{- if .Values.mellon.enabled -}}
 # Defines the ingress for the alfresco content repository
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
@@ -13,21 +13,30 @@ metadata:
 {{ toYaml .Values.repository.ingress.annotations | indent 4 }}
 spec:
   rules:
-  {{- if .Values.externalHost }}
-  - host: {{ tpl .Values.externalHost $ }}
+  {{ $external := .Values.externalHost }}
+  {{- if $external }}
+  - host: {{ tpl $external $ }}
     http:
   {{- else }}
   - http:
   {{- end }}
       paths:
-      - path: {{ .Values.repository.ingress.path }}
+      - path: /mellon
         backend:
-          serviceName: {{ template "content-services.shortname" . }}-repository
-          servicePort: {{ .Values.repository.service.externalPort }}
-      - path: {{ .Values.apiexplorer.ingress.path }}
+          serviceName: {{ template "content-services.shortname" $ }}-apache-mellon
+          servicePort: 80
+      {{- range .Values.mellon.protected_routes }}
+      - path: {{ .path }}
         backend:
-          serviceName: {{ template "content-services.shortname" . }}-repository
-          servicePort: {{ .Values.repository.service.externalPort }}
+          serviceName: {{ template "content-services.shortname" $ }}-apache-mellon
+          servicePort: 80
+      {{- end -}}
+      {{ range .Values.mellon.allowed_routes }}
+      - path: {{ .path }}
+        backend:
+          serviceName: {{ template "content-services.shortname" $ }}-apache-mellon
+          servicePort: 80
+      {{- end -}}
   {{- if .Values.repository.ingress.tls }}
   tls:
 {{ toYaml .Values.repository.ingress.tls | indent 4 }}

--- a/stable/alfresco-content-services-community/templates/ingress-share.yaml
+++ b/stable/alfresco-content-services-community/templates/ingress-share.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.mellon.enabled -}}
 # Defines the ingress for the alfresco share app
 apiVersion: {{ template "ingress.apiVersion" . }}
 kind: Ingress
@@ -27,3 +28,4 @@ spec:
   tls:
 {{ toYaml .Values.share.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}

--- a/stable/alfresco-content-services-community/templates/svc-apache-mellon.yaml
+++ b/stable/alfresco-content-services-community/templates/svc-apache-mellon.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.mellon.enabled -}}
+# Defines the service for the alfresco content repository app
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "content-services.shortname" . }}-apache-mellon
+  labels:
+    app: {{ template "content-services.shortname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: apache-mellon
+spec:
+  type: {{ .Values.repository.service.type }}
+  ports:
+    - port: 80
+      targetPort: 80
+      name: http
+  selector:
+    app: {{ template "content-services.shortname" . }}-apache-mellon
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/stable/alfresco-content-services-community/values.yaml
+++ b/stable/alfresco-content-services-community/values.yaml
@@ -216,6 +216,52 @@ postgresql:
     limits:
       memory: "1500Mi"
 
+mellon:
+  # set to true to activate SAMLv2 authentication
+  enable: false
+  # image to use for apache + mod_auth_mellon
+  image: 3spartnerdockerregistry.azurecr.io/apache-mellon:latest
+  # snippets to add to Apache httpd
+  server_snippets: |
+    <LocationMatch "^(/.*/service/api/solr/.*)$" >
+        deny from all
+    </LocationMatch>
+    <LocationMatch "^(/.*/s/api/solr/.*)$" >
+        deny from all
+    </LocationMatch>
+    <LocationMatch "^(/.*/wcservice/api/solr/.*)$" >
+        deny from all
+    </LocationMatch>
+    <LocationMatch "^(/.*/wcs/api/solr/.*)$">
+        deny from all
+    </LocationMatch>
+  # allowed_routes are routes to leave public
+  allowed_routes: []
+  # protected_routes are restricted to authenticated users
+  # from SAML server
+  protected_routes:
+  - path: /alfresco
+    suffix: -repository
+  - path: /api-explorer
+    suffix: -repository
+  - path: /share
+    suffix: -share
+  # Attributes from SAML to bind to headers
+  saml_attributes:
+  - name: email
+    set_header: X-Alfresco-Remote-Email
+  - name: uid
+    set_header: X-Alfresco-Remote-User
+  # The SP name to register in SAML SDP
+  entity_id: alfresco
+  cert: |
+    # paste here the SP certificate
+  key: |
+    # paste here the SP key
+  idp_metadata: |
+    # paste here the XML content of SDP Metadata
+
+
 
 # If there is a need to pull images from a private docker repo, a secret can be defined in helm and passed as an argument
 # to the install command:

--- a/stable/alfresco-content-services-community/values.yaml
+++ b/stable/alfresco-content-services-community/values.yaml
@@ -255,14 +255,14 @@ mellon:
     set_header: X-Alfresco-Remote-Email
   - name: uid
     set_header: X-Alfresco-Remote-User
-  # The SP name to register in SAML SDP
+  # The SP name to register in SAML IDP
   entity_id: alfresco
   cert: |
     # paste here the SP certificate
   key: |
     # paste here the SP key
   idp_metadata: |
-    # paste here the XML content of SDP Metadata
+    # paste here the XML content of IDP Metadata
 
 
 

--- a/stable/alfresco-content-services-community/values.yaml
+++ b/stable/alfresco-content-services-community/values.yaml
@@ -246,6 +246,9 @@ mellon:
     suffix: -repository
   - path: /share
     suffix: -share
+  # SAML attribute to use with alfresco connector
+  # Note: this attribute MUST be set in saml_attributes !
+  connector_header: X-Alfresco-Remote-User
   # Attributes from SAML to bind to headers
   saml_attributes:
   - name: email


### PR DESCRIPTION
Add `mellon` section to activate Apache Mellon as reverse proxy connected to SAML to authenticate users.
It's enabled via `mellon.enabled` value to activate/deactivate some objects (e.g. using Mellon deactivate previous ingresses)

The documentation explains the procedure (to create the key pair, where to put metadata from SAML server, and which properties to change)

Docker image is on a private repository. But it's a simple Docker image from "centos:7" where is installed "mod_auth_mellon" via `yum` and with command `apachectl -D FOREGROUND`

NOTES: ingress are not touched but are incompatible with newest Nginx-ingress versions, especially Postgres dependencies.